### PR TITLE
Add an easy-to-use default policy system

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Available targets:
 
 | Name |
 |------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
 | [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
 | [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
 
@@ -178,7 +179,12 @@ Available targets:
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| policy | A valid KMS policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | `string` | `""` | no |
+| policy | A valid KMS policy JSON document. Note that if the policy document is not<br>specific enough (but still valid), Terraform may view the policy as<br>constantly changing in a terraform plan. In this case, please make sure you<br>use the verbose/specific version of the policy. This variable takes<br>precedence over other 'policy\_*' variables. | `string` | `""` | no |
+| policy\_extra\_statements | A list of additional IAM policy statements to attach to the key policy.<br>These statements should be in JSON (string) format.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| policy\_key\_admins | A list of AWS principals allowed to administer this key. You can specify<br>ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| policy\_key\_aws\_services | A list of AWS services allowed to use this key.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| policy\_key\_grantors | A list of AWS principals allowed to grant use of this key to AWS resources.<br>You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| policy\_key\_users | A list of AWS principals allowed to use this key for cryptographic<br>operations. You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -136,71 +136,71 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.0 |
-| local | >= 1.3 |
-| null | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| this | cloudposse/label/null | 0.24.1 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
-| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
+| Name | Type |
+|------|------|
+| [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| alias | The display name of the alias. The name must start with the word `alias` followed by a forward slash. If not specified, the alias name will be auto-generated. | `string` | `""` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| customer\_master\_key\_spec | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. | `string` | `"SYMMETRIC_DEFAULT"` | no |
-| deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource | `number` | `10` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| description | The description of the key as viewed in AWS console | `string` | `"Parameter Store KMS master key"` | no |
-| enable\_key\_rotation | Specifies whether key rotation is enabled | `bool` | `true` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| key\_usage | Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT` or `SIGN_VERIFY`. | `string` | `"ENCRYPT_DECRYPT"` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| policy | A valid KMS policy JSON document. Note that if the policy document is not<br>specific enough (but still valid), Terraform may view the policy as<br>constantly changing in a terraform plan. In this case, please make sure you<br>use the verbose/specific version of the policy. This variable takes<br>precedence over other 'policy\_*' variables. | `string` | `""` | no |
-| policy\_extra\_statements | A list of additional IAM policy statements to attach to the key policy.<br>These statements should be in JSON (string) format.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
-| policy\_key\_admins | A list of AWS principals allowed to administer this key. You can specify<br>ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
-| policy\_key\_aws\_services | A list of AWS services allowed to use this key.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
-| policy\_key\_grantors | A list of AWS principals allowed to grant use of this key to AWS resources.<br>You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
-| policy\_key\_users | A list of AWS principals allowed to use this key for cryptographic<br>operations. You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_alias"></a> [alias](#input\_alias) | The display name of the alias. The name must start with the word `alias` followed by a forward slash. If not specified, the alias name will be auto-generated. | `string` | `""` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | Duration in days after which the key is deleted after destruction of the resource | `number` | `10` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the key as viewed in AWS console | `string` | `"Parameter Store KMS master key"` | no |
+| <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_key_usage"></a> [key\_usage](#input\_key\_usage) | Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT` or `SIGN_VERIFY`. | `string` | `"ENCRYPT_DECRYPT"` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | A valid KMS policy JSON document. Note that if the policy document is not<br>specific enough (but still valid), Terraform may view the policy as<br>constantly changing in a terraform plan. In this case, please make sure you<br>use the verbose/specific version of the policy. This variable takes<br>precedence over other 'policy\_*' variables. | `string` | `""` | no |
+| <a name="input_policy_extra_statements"></a> [policy\_extra\_statements](#input\_policy\_extra\_statements) | A list of additional IAM policy statements to attach to the key policy.<br>These statements should be in JSON (string) format.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| <a name="input_policy_key_admins"></a> [policy\_key\_admins](#input\_policy\_key\_admins) | A list of AWS principals allowed to administer this key. You can specify<br>ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| <a name="input_policy_key_aws_services"></a> [policy\_key\_aws\_services](#input\_policy\_key\_aws\_services) | A list of AWS services allowed to use this key.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| <a name="input_policy_key_grantors"></a> [policy\_key\_grantors](#input\_policy\_key\_grantors) | A list of AWS principals allowed to grant use of this key to AWS resources.<br>You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| <a name="input_policy_key_users"></a> [policy\_key\_users](#input\_policy\_key\_users) | A list of AWS principals allowed to use this key for cryptographic<br>operations. You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| alias\_arn | Alias ARN |
-| alias\_name | Alias name |
-| key\_arn | Key ARN |
-| key\_id | Key ID |
+| <a name="output_alias_arn"></a> [alias\_arn](#output\_alias\_arn) | Alias ARN |
+| <a name="output_alias_name"></a> [alias\_name](#output\_alias\_name) | Alias name |
+| <a name="output_key_arn"></a> [key\_arn](#output\_key\_arn) | Key ARN |
+| <a name="output_key_id"></a> [key\_id](#output\_key\_id) | Key ID |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,69 +3,69 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.0 |
-| local | >= 1.3 |
-| null | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| this | cloudposse/label/null | 0.24.1 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
-| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
+| Name | Type |
+|------|------|
+| [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| alias | The display name of the alias. The name must start with the word `alias` followed by a forward slash. If not specified, the alias name will be auto-generated. | `string` | `""` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| customer\_master\_key\_spec | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. | `string` | `"SYMMETRIC_DEFAULT"` | no |
-| deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource | `number` | `10` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| description | The description of the key as viewed in AWS console | `string` | `"Parameter Store KMS master key"` | no |
-| enable\_key\_rotation | Specifies whether key rotation is enabled | `bool` | `true` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| key\_usage | Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT` or `SIGN_VERIFY`. | `string` | `"ENCRYPT_DECRYPT"` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| policy | A valid KMS policy JSON document. Note that if the policy document is not<br>specific enough (but still valid), Terraform may view the policy as<br>constantly changing in a terraform plan. In this case, please make sure you<br>use the verbose/specific version of the policy. This variable takes<br>precedence over other 'policy\_*' variables. | `string` | `""` | no |
-| policy\_extra\_statements | A list of additional IAM policy statements to attach to the key policy.<br>These statements should be in JSON (string) format.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
-| policy\_key\_admins | A list of AWS principals allowed to administer this key. You can specify<br>ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
-| policy\_key\_aws\_services | A list of AWS services allowed to use this key.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
-| policy\_key\_grantors | A list of AWS principals allowed to grant use of this key to AWS resources.<br>You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
-| policy\_key\_users | A list of AWS principals allowed to use this key for cryptographic<br>operations. You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_alias"></a> [alias](#input\_alias) | The display name of the alias. The name must start with the word `alias` followed by a forward slash. If not specified, the alias name will be auto-generated. | `string` | `""` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. | `string` | `"SYMMETRIC_DEFAULT"` | no |
+| <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | Duration in days after which the key is deleted after destruction of the resource | `number` | `10` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the key as viewed in AWS console | `string` | `"Parameter Store KMS master key"` | no |
+| <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_key_usage"></a> [key\_usage](#input\_key\_usage) | Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT` or `SIGN_VERIFY`. | `string` | `"ENCRYPT_DECRYPT"` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | A valid KMS policy JSON document. Note that if the policy document is not<br>specific enough (but still valid), Terraform may view the policy as<br>constantly changing in a terraform plan. In this case, please make sure you<br>use the verbose/specific version of the policy. This variable takes<br>precedence over other 'policy\_*' variables. | `string` | `""` | no |
+| <a name="input_policy_extra_statements"></a> [policy\_extra\_statements](#input\_policy\_extra\_statements) | A list of additional IAM policy statements to attach to the key policy.<br>These statements should be in JSON (string) format.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| <a name="input_policy_key_admins"></a> [policy\_key\_admins](#input\_policy\_key\_admins) | A list of AWS principals allowed to administer this key. You can specify<br>ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| <a name="input_policy_key_aws_services"></a> [policy\_key\_aws\_services](#input\_policy\_key\_aws\_services) | A list of AWS services allowed to use this key.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| <a name="input_policy_key_grantors"></a> [policy\_key\_grantors](#input\_policy\_key\_grantors) | A list of AWS principals allowed to grant use of this key to AWS resources.<br>You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| <a name="input_policy_key_users"></a> [policy\_key\_users](#input\_policy\_key\_users) | A list of AWS principals allowed to use this key for cryptographic<br>operations. You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| alias\_arn | Alias ARN |
-| alias\_name | Alias name |
-| key\_arn | Key ARN |
-| key\_id | Key ID |
+| <a name="output_alias_arn"></a> [alias\_arn](#output\_alias\_arn) | Alias ARN |
+| <a name="output_alias_name"></a> [alias\_name](#output\_alias\_name) | Alias name |
+| <a name="output_key_arn"></a> [key\_arn](#output\_key\_arn) | Key ARN |
+| <a name="output_key_id"></a> [key\_id](#output\_key\_id) | Key ID |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,6 +24,7 @@
 
 | Name |
 |------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
 | [aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) |
 | [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
 
@@ -45,7 +46,12 @@
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| policy | A valid KMS policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | `string` | `""` | no |
+| policy | A valid KMS policy JSON document. Note that if the policy document is not<br>specific enough (but still valid), Terraform may view the policy as<br>constantly changing in a terraform plan. In this case, please make sure you<br>use the verbose/specific version of the policy. This variable takes<br>precedence over other 'policy\_*' variables. | `string` | `""` | no |
+| policy\_extra\_statements | A list of additional IAM policy statements to attach to the key policy.<br>These statements should be in JSON (string) format.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| policy\_key\_admins | A list of AWS principals allowed to administer this key. You can specify<br>ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| policy\_key\_aws\_services | A list of AWS services allowed to use this key.<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `[]` | no |
+| policy\_key\_grantors | A list of AWS principals allowed to grant use of this key to AWS resources.<br>You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
+| policy\_key\_users | A list of AWS principals allowed to use this key for cryptographic<br>operations. You can specify ARNs of IAM users/roles, and AWS account IDs.<br><br>If you do not provide any value for this variable, access will be granted to<br>the entire account. If you do not want any principal to have this access,<br>specify [].<br><br>This variable is ignored if the 'policy' variable is set. | `list(string)` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ locals {
     Statement = concat(
       length(local.policy_key_admins) == 0 ? [] : [{
         Sid = "Allow access for Key Administrators"
+        Effect = "Allow"
         Action = [
           "kms:Create*",
           "kms:Describe*",
@@ -53,6 +54,7 @@ locals {
       }],
       length(local.policy_key_users) == 0 ? [] : [{
         Sid = "Allow use of the key"
+        Effect = "Allow"
         Action = [
           "kms:Encrypt",
           "kms:Decrypt",
@@ -67,6 +69,7 @@ locals {
       }],
       length(local.policy_key_grantors) == 0 ? [] : [{
         Sid = "Allow attachment of persistent resources"
+        Effect = "Allow"
         Action = [
           "kms:CreateGrant",
           "kms:ListGrants",

--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,9 @@ resource "aws_kms_alias" "default" {
 
 locals {
   # Set default of "all of this account" for policy groups
-  policy_key_admins   = var.policy_key_admins != null ? var.policy_key_admins : [data.aws_caller_identity.current.account_id]
-  policy_key_users    = var.policy_key_users != null ? var.policy_key_users : [data.aws_caller_identity.current.account_id]
-  policy_key_grantors = var.policy_key_grantors != null ? var.policy_key_grantors : [data.aws_caller_identity.current.account_id]
+  policy_key_admins   = var.policy_key_admins != null ? var.policy_key_admins : ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+  policy_key_users    = var.policy_key_users != null ? var.policy_key_users : ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+  policy_key_grantors = var.policy_key_grantors != null ? var.policy_key_grantors : ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
 }
 
 data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "aws_kms_key" "default" {
   count                   = module.this.enabled ? 1 : 0
   deletion_window_in_days = var.deletion_window_in_days
   enable_key_rotation     = var.enable_key_rotation
-  policy                  = var.policy
+  policy                  = var.policy != "" ? var.policy : local.default_policy
   tags                    = module.this.tags
   description             = var.description
 }
@@ -11,4 +11,73 @@ resource "aws_kms_alias" "default" {
   count         = module.this.enabled ? 1 : 0
   name          = coalesce(var.alias, format("alias/%v", module.this.id))
   target_key_id = join("", aws_kms_key.default.*.id)
+}
+
+locals {
+  # Set default of "all of this account" for policy groups
+  policy_key_admins   = var.policy_key_admins != null ? var.policy_key_admins : [data.aws_caller_identity.current.account_id]
+  policy_key_users    = var.policy_key_users != null ? var.policy_key_users : [data.aws_caller_identity.current.account_id]
+  policy_key_grantors = var.policy_key_grantors != null ? var.policy_key_grantors : [data.aws_caller_identity.current.account_id]
+}
+
+data "aws_caller_identity" "current" {}
+
+# This is modelled off of the following example key policy:
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-example
+locals {
+  default_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      length(local.policy_key_admins) == 0 ? [] : [{
+        Sid = "Allow access for Key Administrators"
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion"
+        ]
+        Principal = {
+          AWS = local.policy_key_admins
+        }
+        Resource = "*"
+      }],
+      length(local.policy_key_users) == 0 ? [] : [{
+        Sid = "Allow use of the key"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Principal = {
+          AWS = local.policy_key_users
+        }
+        Resource = "*"
+      }],
+      length(local.policy_key_grantors) == 0 ? [] : [{
+        Sid = "Allow attachment of persistent resources"
+        Action = [
+          "kms:CreateGrant",
+          "kms:ListGrants",
+          "kms:RevokeGrant"
+        ]
+        Principal = {
+          AWS = local.policy_key_grantors
+        }
+        Resource = "*"
+      }],
+      var.policy_extra_statements,
+    )
+  })
 }

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,21 @@ locals {
         }
         Resource = "*"
       }],
+      length(var.policy_key_aws_services) == 0 ? [] : [{
+        Sid    = "AWS service usage"
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Principal = {
+          Service = var.policy_key_aws_services
+        }
+        Resource = "*"
+      }],
       length(local.policy_key_grantors) == 0 ? [] : [{
         Sid    = "Allow attachment of persistent resources"
         Effect = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ locals {
     Version = "2012-10-17"
     Statement = concat(
       length(local.policy_key_admins) == 0 ? [] : [{
-        Sid = "Allow access for Key Administrators"
+        Sid    = "Allow access for Key Administrators"
         Effect = "Allow"
         Action = [
           "kms:Create*",
@@ -53,7 +53,7 @@ locals {
         Resource = "*"
       }],
       length(local.policy_key_users) == 0 ? [] : [{
-        Sid = "Allow use of the key"
+        Sid    = "Allow use of the key"
         Effect = "Allow"
         Action = [
           "kms:Encrypt",
@@ -68,7 +68,7 @@ locals {
         Resource = "*"
       }],
       length(local.policy_key_grantors) == 0 ? [] : [{
-        Sid = "Allow attachment of persistent resources"
+        Sid    = "Allow attachment of persistent resources"
         Effect = "Allow"
         Action = [
           "kms:CreateGrant",

--- a/variables.tf
+++ b/variables.tf
@@ -38,8 +38,8 @@ variable "policy_key_admins" {
   type        = list(string)
   default     = null
   description = <<-EOF
-    A list of AWS principals allowed to administer this key. You can specify AWS
-    service principals, ARNs of IAM users/roles, and AWS account IDs.
+    A list of AWS principals allowed to administer this key. You can specify
+    ARNs of IAM users/roles, and AWS account IDs.
 
     If you do not provide any value for this variable, access will be granted to
     the entire account. If you do not want any principal to have this access,
@@ -54,8 +54,7 @@ variable "policy_key_users" {
   default     = null
   description = <<-EOF
     A list of AWS principals allowed to use this key for cryptographic
-    operations. You can specify AWS service principals, ARNs of IAM users/roles,
-    and AWS account IDs.
+    operations. You can specify ARNs of IAM users/roles, and AWS account IDs.
 
     If you do not provide any value for this variable, access will be granted to
     the entire account. If you do not want any principal to have this access,
@@ -70,12 +69,21 @@ variable "policy_key_grantors" {
   default     = null
   description = <<-EOF
     A list of AWS principals allowed to grant use of this key to AWS resources.
-    You can specify AWS service principals, ARNs of IAM users/roles, and AWS
-    account IDs.
+    You can specify ARNs of IAM users/roles, and AWS account IDs.
 
     If you do not provide any value for this variable, access will be granted to
     the entire account. If you do not want any principal to have this access,
     specify [].
+
+    This variable is ignored if the 'policy' variable is set.
+  EOF
+}
+
+variable "policy_key_aws_services" {
+  type        = list(string)
+  default     = []
+  description = <<-EOF
+    A list of AWS services allowed to use this key.
 
     This variable is ignored if the 'policy' variable is set.
   EOF

--- a/variables.tf
+++ b/variables.tf
@@ -38,8 +38,8 @@ variable "policy_key_admins" {
   type        = list(string)
   default     = null
   description = <<-EOF
-    A list of AWS principals allowed to administer this key. You can specify the
-    ARNs of IAM users or groups, or AWS account IDs.
+    A list of AWS principals allowed to administer this key. You can specify AWS
+    service principals, ARNs of IAM users/roles, and AWS account IDs.
 
     If you do not provide any value for this variable, access will be granted to
     the entire account. If you do not want any principal to have this access,
@@ -54,8 +54,8 @@ variable "policy_key_users" {
   default     = null
   description = <<-EOF
     A list of AWS principals allowed to use this key for cryptographic
-    operations. You can specify the ARNs of IAM users or groups, or AWS account
-    IDs.
+    operations. You can specify AWS service principals, ARNs of IAM users/roles,
+    and AWS account IDs.
 
     If you do not provide any value for this variable, access will be granted to
     the entire account. If you do not want any principal to have this access,
@@ -70,8 +70,8 @@ variable "policy_key_grantors" {
   default     = null
   description = <<-EOF
     A list of AWS principals allowed to grant use of this key to AWS resources.
-    You can specify the ARNs of IAM users or groups, or AWS account
-    IDs.
+    You can specify AWS service principals, ARNs of IAM users/roles, and AWS
+    account IDs.
 
     If you do not provide any value for this variable, access will be granted to
     the entire account. If you do not want any principal to have this access,

--- a/variables.tf
+++ b/variables.tf
@@ -25,5 +25,69 @@ variable "alias" {
 variable "policy" {
   type        = string
   default     = ""
-  description = "A valid KMS policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy."
+  description = <<-EOF
+    A valid KMS policy JSON document. Note that if the policy document is not
+    specific enough (but still valid), Terraform may view the policy as
+    constantly changing in a terraform plan. In this case, please make sure you
+    use the verbose/specific version of the policy. This variable takes
+    precedence over other 'policy_*' variables.
+  EOF
+}
+
+variable "policy_key_admins" {
+  type        = list(string)
+  default     = null
+  description = <<-EOF
+    A list of AWS principals allowed to administer this key. You can specify the
+    ARNs of IAM users or groups, or AWS account IDs.
+
+    If you do not provide any value for this variable, access will be granted to
+    the entire account. If you do not want any principal to have this access,
+    specify [].
+
+    This variable is ignored if the 'policy' variable is set.
+  EOF
+}
+
+variable "policy_key_users" {
+  type        = list(string)
+  default     = null
+  description = <<-EOF
+    A list of AWS principals allowed to use this key for cryptographic
+    operations. You can specify the ARNs of IAM users or groups, or AWS account
+    IDs.
+
+    If you do not provide any value for this variable, access will be granted to
+    the entire account. If you do not want any principal to have this access,
+    specify [].
+
+    This variable is ignored if the 'policy' variable is set.
+  EOF
+}
+
+variable "policy_key_grantors" {
+  type        = list(string)
+  default     = null
+  description = <<-EOF
+    A list of AWS principals allowed to grant use of this key to AWS resources.
+    You can specify the ARNs of IAM users or groups, or AWS account
+    IDs.
+
+    If you do not provide any value for this variable, access will be granted to
+    the entire account. If you do not want any principal to have this access,
+    specify [].
+
+    This variable is ignored if the 'policy' variable is set.
+  EOF
+}
+
+variable "policy_extra_statements" {
+  type        = list(string)
+  default     = []
+  description = <<-EOF
+    A list of additional IAM policy statements to attach to the key policy.
+    These statements should be in JSON (string) format.
+
+    This variable is ignored if the 'policy' variable is set.
+  EOF
 }


### PR DESCRIPTION
Instead of relying on KMS to generate a default policy, generate one
ourselves, and expose some new variables for users to easily modify it.

Now users can explicitly specify who (if anyone) should be key admins,
users and grantors. Additionally, they can add custom statements to the
default policy to simplify adding small grants.

Closes #25.