### PR TITLE
Fix: Update Version Constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,18 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
+      version = ">= 3.64.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.64.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Provider bump

## why
* Prevent stale .terraform directories from preventing planning this module

## references
* https://github.com/cloudposse/terraform-aws-kms-key/pull/30

